### PR TITLE
Better document Node.js + npm required versions

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,2 @@
+20
+lts/hydrogen

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-# genesys-base-styles
+# Genesys Base Styles
 
-The official Genesys base styles repository.
+The official Genesys base-styles repository
+
+## Requirements
+
+* Node.js &ge; 18
+* npm &ge; 8
 
 ## Quick start
 


### PR DESCRIPTION
We already specify Node.js &ge; v18 in `engines` field.

Complete that with an explicit mention on the README, and add an `nvm` init file to that end.